### PR TITLE
exit Immersive Display System by keybind

### DIFF
--- a/include/zen/appearance/system.h
+++ b/include/zen/appearance/system.h
@@ -13,6 +13,8 @@ struct zna_system;
 void zna_system_set_current_session(
     struct zna_system *self, struct znr_session *session);
 
+void zna_system_setup_keybindings(struct zna_system *self);
+
 struct zna_system *zna_system_create(struct wl_display *display);
 
 void zna_system_destroy(struct zna_system *self);

--- a/zen/server.c
+++ b/zen/server.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_output.h>
 #include <zen-common.h>
 
+#include "zen/appearance/system.h"
 #include "zen/config/config-parser.h"
 #include "zen/config/config.h"
 #include "zen/cursor.h"
@@ -265,6 +266,7 @@ zn_server_create(struct wl_display *display)
   }
 
   zn_scene_setup_keybindings(self->scene);
+  zna_system_setup_keybindings(self->appearance_system);
 
   self->new_input_listener.notify = zn_server_handle_new_input;
   wl_signal_add(


### PR DESCRIPTION
## Context

We want to leave Immersive Display System by pressing Meta+V

## Summary

Add keybind about leaving

## How to check behavior

Start zen, connect to zen-mirror, and press Meta+V