### PR TITLE
Use SVG icon at App Launcher

### DIFF
--- a/zen/ui/nodes/app-launcher.c
+++ b/zen/ui/nodes/app-launcher.c
@@ -23,6 +23,12 @@ zn_app_launcher_render(struct zigzag_node *node, cairo_t *cr)
   static const double padding = 6.;
   const double icon_size = menu_bar_height - 2 * padding;
 
+  if (zigzag_cairo_stamp_svg_on_surface(cr, self->app->icon,
+          node->frame.width / 2 - icon_size / 2,
+          node->frame.height / 2 - icon_size / 2, icon_size, icon_size)) {
+    return true;
+  }
+
   double surface_width =
       cairo_image_surface_get_width(self->launcher_icon_surface);
   double surface_height =


### PR DESCRIPTION
## Context

We can specify the icon of the app launcher by config, but only PNG image file was acceptable.

## Summary

Try to render icon as SVG

## How to check behavior

Add app launcher item using SVG file as icon to config.