### PR TITLE
Enable to build glew with clang-15

### DIFF
--- a/subprojects/packagefiles/glew/meson.build
+++ b/subprojects/packagefiles/glew/meson.build
@@ -27,6 +27,7 @@ c_args += cc.get_supported_arguments([
   '-Wcast-qual',
   '-fno-stack-protector',
   '-Wno-visibility',
+  '-Wno-strict-prototypes'
 ])
 
 glew_sources = [


### PR DESCRIPTION
## Context

With clang-15, zen fails to build GLEW like so.

```
../subprojects/glew-2.2.0/src/glew.c:10017:54: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static GLboolean _glewInit_GL_AMD_draw_buffers_blend ();
                                                     ^
                                                      void
../subprojects/glew-2.2.0/src/glew.c:10018:68: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static GLboolean _glewInit_GL_AMD_framebuffer_multisample_advanced ();
                                                                   ^
                                                                    void
../subprojects/glew-2.2.0/src/glew.c:10019:64: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static GLboolean _glewInit_GL_AMD_framebuffer_sample_positions ();
                                                               ^
                                                                void
../subprojects/glew-2.2.0/src/glew.c:10020:56: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
static GLboolean _glewInit_GL_AMD_interleaved_elements ();
                                                       ^
                                                        void
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[42/191] Compiling C object zwnroot/libzwnr.a.p/src_region_node.c.o
ninja: build stopped: subcommand failed.
```

## Summary

- Add '-Wno-strict-prototypes' to compiler arguments of building GLEW.

To officially support clang-15, we still need to add clang-15 build test to CI.

## How to check behavior

Build it with clang-15.
```
CC=clang-15 CXX=clang++-15 meson build
ninja -C build
```