### PR TITLE
Cursor motion

### DIFF
--- a/common/include/zen-common/log.h
+++ b/common/include/zen-common/log.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum {
   ZEN_SILENT = 0,

--- a/common/include/zen-common/signal.h
+++ b/common/include/zen-common/signal.h
@@ -2,4 +2,12 @@
 
 #include <wayland-server-core.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void zn_signal_emit_mutable(struct wl_signal *signal, void *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/include/zen-common/timespec-util.h
+++ b/common/include/zen-common/timespec-util.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <stdint.h>
+#include <time.h>
+
 #include "zen-common/util.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
-#include <time.h>
 
 enum {
   NSEC_PER_SEC = 1000000000,

--- a/common/include/zen-common/util.h
+++ b/common/include/zen-common/util.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stddef.h>
-#include <stdlib.h>
 
 /** Visibility attribute */
 #if defined(__GNUC__) && __GNUC__ >= 4

--- a/common/include/zen-common/wlr/box.h
+++ b/common/include/zen-common/wlr/box.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <wlr/util/box.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void zn_wlr_fbox_closest_point(const struct wlr_fbox *box, double x, double y,
+    double *dest_x, double *dest_y);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/meson.build
+++ b/common/meson.build
@@ -2,6 +2,7 @@ _zen_common_srcs = [
   'src/log.c',
   'src/signal.c',
   'src/terminate.c',
+  'src/wlr/box.c',
 ]
 
 _zen_common_inc = include_directories('include')

--- a/common/src/wlr/box.c
+++ b/common/src/wlr/box.c
@@ -1,0 +1,31 @@
+#include "zen-common/wlr/box.h"
+
+void
+zn_wlr_fbox_closest_point(const struct wlr_fbox *box, double x, double y,
+    double *dest_x, double *dest_y)
+{
+  // if box is empty, then it contains no points, so no closest point either
+  if (box->width <= 0 || box->height <= 0) {
+    *dest_x = NAN;
+    *dest_y = NAN;
+    return;
+  }
+
+  // find the closest x point
+  if (x < box->x) {
+    *dest_x = box->x;
+  } else if (x >= box->x + box->width) {
+    *dest_x = box->x + box->width;
+  } else {
+    *dest_x = x;
+  }
+
+  // find closest y point
+  if (y < box->y) {
+    *dest_y = box->y;
+  } else if (y >= box->y + box->height) {
+    *dest_y = box->y + box->height;
+  } else {
+    *dest_y = y;
+  }
+}

--- a/desktop/include/zen-desktop/cursor-grab.h
+++ b/desktop/include/zen-desktop/cursor-grab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cglm/types.h>
 #include <wlr/types/wlr_pointer.h>
 
 #include "zen-common/util.h"
@@ -8,7 +9,7 @@ struct zn_cursor_grab;
 
 struct zn_cursor_grab_interface {
   void (*motion_relative)(
-      struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec);
+      struct zn_cursor_grab *grab, vec2 delta, uint32_t time_msec);
   void (*destroy)(struct zn_cursor_grab *grab);
 };
 
@@ -18,9 +19,9 @@ struct zn_cursor_grab {
 
 UNUSED static void
 zn_cursor_grab_pointer_motion(
-    struct zn_cursor_grab *self, double dx, double dy, uint32_t time_msec)
+    struct zn_cursor_grab *self, vec2 delta, uint32_t time_msec)
 {
-  self->impl->motion_relative(self, dx, dy, time_msec);
+  self->impl->motion_relative(self, delta, time_msec);
 }
 
 UNUSED static void

--- a/desktop/include/zen-desktop/cursor-grab.h
+++ b/desktop/include/zen-desktop/cursor-grab.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <wlr/types/wlr_pointer.h>
+
+#include "zen-common/util.h"
+
+struct zn_cursor_grab;
+
+struct zn_cursor_grab_interface {
+  void (*motion_relative)(
+      struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec);
+  void (*destroy)(struct zn_cursor_grab *grab);
+};
+
+struct zn_cursor_grab {
+  const struct zn_cursor_grab_interface *impl;  // @nonnull, @outlive
+};
+
+UNUSED static void
+zn_cursor_grab_pointer_motion(
+    struct zn_cursor_grab *self, double dx, double dy, uint32_t time_msec)
+{
+  self->impl->motion_relative(self, dx, dy, time_msec);
+}
+
+UNUSED static void
+zn_cursor_grab_destroy(struct zn_cursor_grab *self)
+{
+  self->impl->destroy(self);
+}

--- a/desktop/include/zen-desktop/cursor-grab/default.h
+++ b/desktop/include/zen-desktop/cursor-grab/default.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "zen-desktop/cursor-grab.h"
+
+struct zn_cursor_default_grab {
+  struct zn_cursor_grab base;
+};
+
+struct zn_cursor_default_grab *zn_cursor_default_grab_create(void);

--- a/desktop/include/zen-desktop/screen-layout.h
+++ b/desktop/include/zen-desktop/screen-layout.h
@@ -3,11 +3,24 @@
 #include <cglm/types.h>
 #include <wayland-server-core.h>
 
+struct zn_screen;
 struct zn_screen_container;
 
 struct zn_screen_layout {
   struct wl_list screen_container_list;  // zn_screen_container::link
 };
+
+/// @param screen : nonnull
+/// @param position : effective coord
+/// @param position_out : effective coord
+/// position and position_out can be the same one
+void zn_screen_layout_get_closest_position(struct zn_screen_layout *self,
+    struct zn_screen *screen, vec2 position, struct zn_screen **screen_out,
+    vec2 position_out);
+
+/// @return value is nullable
+struct zn_screen *zn_screen_layout_get_main_screen(
+    struct zn_screen_layout *self);
 
 /// Adjust the position of the screens so that they are all adjacent to each
 /// other and do not overlap, while preserving positional relationships as much

--- a/desktop/include/zen-desktop/shell.h
+++ b/desktop/include/zen-desktop/shell.h
@@ -5,7 +5,10 @@
 struct zn_desktop_shell {
   struct zn_screen_layout *screen_layout;  // @nonnull, @owning
 
+  struct zn_cursor_grab *cursor_grab;  // @nonnull, @owning
+
   struct wl_listener new_screen_listener;
+  struct wl_listener pointer_motion_listener;
 };
 
 struct zn_desktop_shell *zn_desktop_shell_get_singleton(void);

--- a/desktop/meson.build
+++ b/desktop/meson.build
@@ -1,4 +1,5 @@
 _zen_desktop_srcs = [
+  'src/cursor-grab/default.c',
   'src/screen-container.c',
   'src/screen-layout.c',
   'src/shell.c',

--- a/desktop/src/cursor-grab/default.c
+++ b/desktop/src/cursor-grab/default.c
@@ -1,0 +1,54 @@
+#include "zen-desktop/cursor-grab/default.h"
+
+#include "zen-common/log.h"
+#include "zen-common/util.h"
+
+static void zn_cursor_default_grab_destroy(struct zn_cursor_default_grab *self);
+
+static struct zn_cursor_default_grab *
+zn_cursor_default_grab_get(struct zn_cursor_grab *grab)
+{
+  struct zn_cursor_default_grab *self = zn_container_of(grab, self, base);
+  return self;
+}
+
+static void
+zn_cursor_default_grab_handle_motion_relative(
+    struct zn_cursor_grab *grab UNUSED, double dx UNUSED, double dy UNUSED,
+    uint32_t time_msec UNUSED)
+{}
+
+static void
+zn_cursor_default_grab_handle_destroy(struct zn_cursor_grab *grab)
+{
+  struct zn_cursor_default_grab *self = zn_cursor_default_grab_get(grab);
+  zn_cursor_default_grab_destroy(self);
+}
+
+static const struct zn_cursor_grab_interface implementation = {
+    .motion_relative = zn_cursor_default_grab_handle_motion_relative,
+    .destroy = zn_cursor_default_grab_handle_destroy,
+};
+
+struct zn_cursor_default_grab *
+zn_cursor_default_grab_create(void)
+{
+  struct zn_cursor_default_grab *self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->base.impl = &implementation;
+
+  return self;
+
+err:
+  return NULL;
+}
+
+static void
+zn_cursor_default_grab_destroy(struct zn_cursor_default_grab *self)
+{
+  free(self);
+}

--- a/desktop/src/cursor-grab/default.c
+++ b/desktop/src/cursor-grab/default.c
@@ -1,7 +1,16 @@
 #include "zen-desktop/cursor-grab/default.h"
 
+#include <cglm/vec2.h>
+
 #include "zen-common/log.h"
 #include "zen-common/util.h"
+#include "zen-desktop/screen-layout.h"
+#include "zen-desktop/shell.h"
+#include "zen/cursor.h"
+#include "zen/screen.h"
+#include "zen/seat.h"
+#include "zen/server.h"
+#include "zen/snode.h"
 
 static void zn_cursor_default_grab_destroy(struct zn_cursor_default_grab *self);
 
@@ -14,9 +23,32 @@ zn_cursor_default_grab_get(struct zn_cursor_grab *grab)
 
 static void
 zn_cursor_default_grab_handle_motion_relative(
-    struct zn_cursor_grab *grab UNUSED, double dx UNUSED, double dy UNUSED,
-    uint32_t time_msec UNUSED)
-{}
+    struct zn_cursor_grab *grab UNUSED, vec2 delta, uint32_t time_msec UNUSED)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct zn_desktop_shell *shell = zn_desktop_shell_get_singleton();
+  struct zn_cursor *cursor = server->seat->cursor;
+  struct zn_screen *screen = cursor->snode->screen;
+  vec2 position;
+
+  if (!screen) {
+    screen = zn_screen_layout_get_main_screen(shell->screen_layout);
+
+    if (!screen) {
+      return;
+    }
+
+    glm_vec2_divs(screen->size, 2, position);
+  } else {
+    glm_vec2_add(cursor->snode->position, delta, position);
+    zn_screen_layout_get_closest_position(
+        shell->screen_layout, screen, position, &screen, position);
+  }
+
+  zn_snode_set_position(cursor->snode, screen->snode_root, position);
+
+  // TODO(@Aki-7) : send events to views, etc
+}
 
 static void
 zn_cursor_default_grab_handle_destroy(struct zn_cursor_grab *grab)

--- a/desktop/src/screen-layout.c
+++ b/desktop/src/screen-layout.c
@@ -1,11 +1,86 @@
 #include "zen-desktop/screen-layout.h"
 
 #include <cglm/vec2.h>
+#include <math.h>
 
 #include "zen-common/log.h"
 #include "zen-common/util.h"
+#include "zen-common/wlr/box.h"
 #include "zen-desktop/screen-container.h"
 #include "zen/screen.h"
+
+/// @param screen : nonnull
+static void
+zn_screen_layout_effective_to_layout_coords(struct zn_screen_layout *self,
+    struct zn_screen *screen, vec2 effective, vec2 layout)
+{
+  struct zn_screen_container *container = NULL;
+  wl_list_for_each (container, &self->screen_container_list, link) {
+    if (container->screen == screen) {
+      glm_vec2_add(container->position, effective, layout);
+      return;
+    }
+  }
+
+  zn_assert(false, "All screen must be in the screen layout");
+}
+
+void
+zn_screen_layout_get_closest_position(struct zn_screen_layout *self,
+    struct zn_screen *screen, vec2 position, struct zn_screen **screen_out,
+    vec2 position_out)
+{
+  vec2 layout_position = GLM_VEC2_ZERO_INIT;
+  double closest_distance = DBL_MAX;  // Manhattan distance
+  struct zn_screen_container *container = NULL;
+
+  zn_screen_layout_effective_to_layout_coords(
+      self, screen, position, layout_position);
+
+  *screen_out = NULL;
+  glm_vec2_zero(position_out);
+
+  wl_list_for_each (container, &self->screen_container_list, link) {
+    double current_closest_x = 0;               // layout coords
+    double current_closest_y = 0;               // layout coords
+    double current_closest_distance = DBL_MAX;  // Manhattan distance
+
+    // layout coords
+    struct wlr_fbox container_fbox = {
+        .x = container->position[0],
+        .y = container->position[1],
+        .width = container->screen->size[0],
+        .height = container->screen->size[1],
+    };
+
+    zn_wlr_fbox_closest_point(&container_fbox, layout_position[0],
+        layout_position[1], &current_closest_x, &current_closest_y);
+
+    current_closest_distance = fabs(current_closest_x - layout_position[0]) +
+                               fabs(current_closest_y - layout_position[1]);
+
+    if (current_closest_distance < closest_distance) {
+      closest_distance = current_closest_distance;
+      glm_vec2_sub((vec2){(float)current_closest_x, (float)current_closest_y},
+          container->position, position_out);
+      *screen_out = container->screen;
+    }
+  }
+}
+
+struct zn_screen *
+zn_screen_layout_get_main_screen(struct zn_screen_layout *self)
+{
+  // TODO(@Aki-7): It's naive implementation
+  if (wl_list_empty(&self->screen_container_list)) {
+    return NULL;
+  }
+
+  struct zn_screen_container *container =
+      zn_container_of(self->screen_container_list.next, container, link);
+
+  return container->screen;
+}
 
 void
 zn_screen_layout_reposition(struct zn_screen_layout *self)

--- a/desktop/src/shell.c
+++ b/desktop/src/shell.c
@@ -32,8 +32,9 @@ zn_desktop_shell_handle_pointer_motion(struct wl_listener *listener, void *data)
   struct zn_desktop_shell *self =
       zn_container_of(listener, self, pointer_motion_listener);
   struct wlr_event_pointer_motion *event = data;
-  zn_cursor_grab_pointer_motion(
-      self->cursor_grab, event->delta_x, event->delta_y, event->time_msec);
+  vec2 delta = {(float)event->delta_x, (float)event->delta_y};
+
+  zn_cursor_grab_pointer_motion(self->cursor_grab, delta, event->time_msec);
 }
 
 struct zn_desktop_shell *

--- a/desktop/tests/meson.build
+++ b/desktop/tests/meson.build
@@ -7,6 +7,8 @@ _zen_desktop_unit_tests_deps = [
 ]
 
 _zen_desktop_unit_tests = {
+  'screen-layout/closest.c': {},
+  'screen-layout/get-main.c': {},
   'screen-layout/layout.c': {},
 }
 

--- a/desktop/tests/screen-layout/closest.c
+++ b/desktop/tests/screen-layout/closest.c
@@ -1,0 +1,108 @@
+#include <cglm/vec2.h>
+
+#include "setup.h"
+#include "test-harness.h"
+#include "zen-desktop/screen-container.h"
+#include "zen-desktop/screen-layout.h"
+
+TEST(get_closest_position)
+{
+  struct wl_display *display = wl_display_create();
+  setup(display);
+
+  struct zn_desktop_shell *shell = zn_desktop_shell_get_singleton();
+
+  struct zn_mock_output *output1 = zn_mock_output_create(1920, 1080);
+  struct zn_mock_output *output2 = zn_mock_output_create(720, 480);
+  struct zn_mock_output *output3 = zn_mock_output_create(1280, 720);
+
+  struct zn_screen_container *container1 =
+      zn_screen_container_create(output1->screen);
+  struct zn_screen_container *container2 =
+      zn_screen_container_create(output2->screen);
+  struct zn_screen_container *container3 =
+      zn_screen_container_create(output3->screen);
+
+  zn_screen_layout_add(shell->screen_layout, container1);
+  zn_screen_layout_add(shell->screen_layout, container2);
+  zn_screen_layout_add(shell->screen_layout, container3);
+
+  struct zn_screen *screen_out = NULL;
+  vec2 position;
+
+  /**
+   * Inside the screen.
+   */
+  glm_vec2_copy((vec2){100, 200}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+
+  ASSERT_EQUAL_POINTER(output1->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(100, position[0]);
+  ASSERT_EQUAL_DOUBLE(200, position[1]);
+
+  glm_vec2_copy((vec2){700, 480}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output2->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output2->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(700, position[0]);
+  ASSERT_EQUAL_DOUBLE(480, position[1]);
+
+  /**
+   * Outside the screen, and the closest screen is the same screen.
+   */
+  glm_vec2_copy((vec2){-100, -200}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output1->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(0, position[0]);
+  ASSERT_EQUAL_DOUBLE(0, position[1]);
+
+  glm_vec2_copy((vec2){100, 1100}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output1->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(100, position[0]);
+  ASSERT_EQUAL_DOUBLE(1080, position[1]);
+
+  glm_vec2_copy((vec2){300, 500}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output2->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output2->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(300, position[0]);
+  ASSERT_EQUAL_DOUBLE(480, position[1]);
+
+  /**
+   * Outside the screen, and the closest screen is the different screen.
+   */
+  glm_vec2_copy((vec2){1920 + 200, 480 + 100}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output2->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(200, position[0]);
+  ASSERT_EQUAL_DOUBLE(480, position[1]);
+
+  /**
+   * Inside the different screen
+   */
+  glm_vec2_copy((vec2){1920 + 200, 380}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+  ASSERT_EQUAL_POINTER(output2->screen, screen_out);
+  ASSERT_EQUAL_DOUBLE(200, position[0]);
+  ASSERT_EQUAL_DOUBLE(380, position[1]);
+
+  /**
+   * Border
+   */
+  glm_vec2_copy((vec2){1920, 380}, position);
+  zn_screen_layout_get_closest_position(
+      shell->screen_layout, output1->screen, position, &screen_out, position);
+  ASSERT_EQUAL_BOOL(
+      true, (screen_out == output1->screen && position[0] == 1920) ||
+                (screen_out == output2->screen && position[1] == 0));
+  ASSERT_EQUAL_DOUBLE(380, position[1]);
+
+  teardown();
+  wl_display_destroy(display);
+}

--- a/desktop/tests/screen-layout/get-main.c
+++ b/desktop/tests/screen-layout/get-main.c
@@ -1,0 +1,53 @@
+#include "setup.h"
+#include "test-harness.h"
+#include "zen-desktop/screen-container.h"
+#include "zen-desktop/screen-layout.h"
+
+TEST(noop)
+{
+  struct wl_display *display = wl_display_create();
+  setup(display);
+
+  struct zn_desktop_shell *shell = zn_desktop_shell_get_singleton();
+
+  struct zn_mock_output *output1 = zn_mock_output_create(1920, 1080);
+  struct zn_mock_output *output2 = zn_mock_output_create(720, 480);
+  struct zn_mock_output *output3 = zn_mock_output_create(1280, 720);
+
+  struct zn_screen_container *container1 =
+      zn_screen_container_create(output1->screen);
+  struct zn_screen_container *container2 =
+      zn_screen_container_create(output2->screen);
+  struct zn_screen_container *container3 =
+      zn_screen_container_create(output3->screen);
+
+  ASSERT_EQUAL_POINTER(
+      NULL, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_screen_layout_add(shell->screen_layout, container1);
+  ASSERT_EQUAL_POINTER(
+      output1->screen, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_screen_layout_add(shell->screen_layout, container2);
+  ASSERT_EQUAL_POINTER(
+      output1->screen, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_screen_layout_add(shell->screen_layout, container3);
+  ASSERT_EQUAL_POINTER(
+      output1->screen, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_mock_output_destroy(output1);
+  ASSERT_EQUAL_POINTER(
+      output2->screen, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_mock_output_destroy(output2);
+  ASSERT_EQUAL_POINTER(
+      output3->screen, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  zn_mock_output_destroy(output3);
+  ASSERT_EQUAL_POINTER(
+      NULL, zn_screen_layout_get_main_screen(shell->screen_layout));
+
+  teardown();
+  wl_display_destroy(display);
+}

--- a/desktop/tests/screen-layout/layout.c
+++ b/desktop/tests/screen-layout/layout.c
@@ -1,27 +1,10 @@
 #include "mock/backend.h"
 #include "mock/output.h"
+#include "setup.h"
 #include "test-harness.h"
 #include "zen-desktop/screen-container.h"
 #include "zen-desktop/screen-layout.h"
 #include "zen-desktop/shell.h"
-#include "zen/server.h"
-
-static void
-setup(struct wl_display *display)
-{
-  struct zn_mock_backend *backend = zn_mock_backend_create();
-  zn_server_create(display, &backend->base);
-  zn_desktop_shell_create();
-}
-
-static void
-teardown(void)
-{
-  struct zn_server *server = zn_server_get_singleton();
-  struct zn_desktop_shell *shell = zn_desktop_shell_get_singleton();
-  zn_desktop_shell_destroy(shell);
-  zn_server_destroy(server);
-}
 
 TEST(add_remove_output)
 {

--- a/desktop/tests/screen-layout/setup.h
+++ b/desktop/tests/screen-layout/setup.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "mock/backend.h"
+#include "mock/output.h"
+#include "zen-common/util.h"
+#include "zen-desktop/shell.h"
+#include "zen/server.h"
+
+UNUSED static void
+setup(struct wl_display *display)
+{
+  struct zn_mock_backend *backend = zn_mock_backend_create();
+  zn_server_create(display, &backend->base);
+  zn_desktop_shell_create();
+}
+
+UNUSED static void
+teardown(void)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct zn_desktop_shell *shell = zn_desktop_shell_get_singleton();
+  zn_desktop_shell_destroy(shell);
+  zn_server_destroy(server);
+}

--- a/zen/include/zen/backend.h
+++ b/zen/include/zen/backend.h
@@ -6,11 +6,16 @@
 
 struct zn_backend;
 
+/// Within the lifetime of zn_backend, the start and stop methods can be called
+/// in this order only once each.
 struct zn_backend_interface {
   struct wlr_texture *(*create_wlr_texture_from_pixels)(struct zn_backend *self,
       uint32_t format, uint32_t stride, uint32_t width, uint32_t height,
       const void *data);
+  /// Starts monitoring the connection or disconnection of input/output devices.
   bool (*start)(struct zn_backend *self);
+  /// Destroy input/output devices
+  void (*stop)(struct zn_backend *self);
   void (*destroy)(struct zn_backend *self);
 };
 
@@ -27,6 +32,12 @@ UNUSED static inline bool
 zn_backend_start(struct zn_backend *self)
 {
   return self->impl->start(self);
+}
+
+UNUSED static inline void
+zn_backend_stop(struct zn_backend *self)
+{
+  self->impl->stop(self);
 }
 
 UNUSED static inline void

--- a/zen/include/zen/snode.h
+++ b/zen/include/zen/snode.h
@@ -39,10 +39,9 @@ struct zn_snode {
 };
 
 /// @param parent is nullable
-/// @param x is in the parent local coords
-/// @param y is in the parent local coords
+/// @param position is in the parent local coords
 void zn_snode_set_position(
-    struct zn_snode *self, struct zn_snode *parent, float x, float y);
+    struct zn_snode *self, struct zn_snode *parent, vec2 position);
 
 /// @return value is nullable
 struct wlr_texture *zn_snode_get_texture(struct zn_snode *self);

--- a/zen/src/backend/backend.h
+++ b/zen/src/backend/backend.h
@@ -7,7 +7,9 @@ struct zn_default_backend {
 
   struct wl_display *display;  // @nonnull, @outlive
 
-  struct wlr_backend *wlr_backend;      // @nonnull, @owning
+  /// It's null after zn_backend stops, nonnull otherwise
+  struct wlr_backend *wlr_backend;  // @nullable, @owning
+
   struct wlr_renderer *wlr_renderer;    // @nonnull, @owning
   struct wlr_allocator *wlr_allocator;  // @nonnull, @owning
 

--- a/zen/src/backend/output.c
+++ b/zen/src/backend/output.c
@@ -302,6 +302,11 @@ zn_output_destroy(struct zn_output *self)
   zn_screen_destroy(self->screen);
   wl_list_remove(&self->damage_frame_listener.link);
   wl_list_remove(&self->wlr_output_destroy_listener.link);
-  wl_list_remove(&self->damage_frame_listener.link);
+
+  /**
+   * Uncommenting this will cause error as wlr_output_damage does not do
+   * wl_list_remove(&damage->events.frame)
+   */
+  // wl_list_remove(&self->damage_frame_listener.link);
   free(self);
 }

--- a/zen/src/backend/output.c
+++ b/zen/src/backend/output.c
@@ -263,7 +263,7 @@ zn_output_create(struct wlr_output *wlr_output)
   self->wlr_output_destroy_listener.notify =
       zn_output_handle_wlr_output_destroy;
   wl_signal_add(
-      &self->wlr_output->events.destroy, &self->wlr_output_destroy_listener);
+      &self->damage->events.destroy, &self->wlr_output_destroy_listener);
 
   self->damage_frame_listener.notify = zn_output_handle_damage_frame;
   wl_signal_add(&self->damage->events.frame, &self->damage_frame_listener);

--- a/zen/src/cursor.c
+++ b/zen/src/cursor.c
@@ -55,6 +55,10 @@ zn_cursor_create(void)
     self->xcursor_texture = zn_backend_create_wlr_texture_from_pixels(
         server->backend, DRM_FORMAT_ARGB8888, image->width * 4, image->width,
         image->height, image->buffer);
+    if (self->xcursor_texture == NULL) {
+      zn_error("Failed to create xcursor texture");
+      goto err_xcursor_manager;
+    }
   }
 
   return self;

--- a/zen/src/server.c
+++ b/zen/src/server.c
@@ -47,6 +47,8 @@ zn_server_terminate(struct zn_server *self, int exit_status)
     return;
   }
 
+  zn_backend_stop(self->backend);
+
   self->running = false;
   self->exit_status = exit_status;
 

--- a/zen/src/snode.c
+++ b/zen/src/snode.c
@@ -42,7 +42,7 @@ zn_snode_cache_absolute_position(struct zn_snode *self)
 
 void
 zn_snode_set_position(
-    struct zn_snode *self, struct zn_snode *parent, float x, float y)
+    struct zn_snode *self, struct zn_snode *parent, vec2 position)
 {
   zn_snode_damage_whole(self);
 
@@ -64,8 +64,7 @@ zn_snode_set_position(
 
   self->parent = parent;
   self->screen = parent ? parent->screen : NULL;
-  self->position[0] = x;
-  self->position[1] = y;
+  glm_vec2_copy(position, self->position);
 
   zn_snode_cache_absolute_position(self);
 
@@ -118,7 +117,7 @@ zn_snode_handle_parent_destroy(struct wl_listener *listener, void *data UNUSED)
   struct zn_snode *self =
       zn_container_of(listener, self, parent_destroy_listener);
 
-  zn_snode_set_position(self, NULL, 0, 0);
+  zn_snode_set_position(self, NULL, GLM_VEC2_ZERO);
 }
 
 struct zn_snode *

--- a/zen/tests/mock/src/backend.c
+++ b/zen/tests/mock/src/backend.c
@@ -26,6 +26,10 @@ zn_mock_backend_start(struct zn_backend *base UNUSED)
 }
 
 static void
+zn_mock_backend_stop(struct zn_backend *base UNUSED)
+{}
+
+static void
 zn_mock_backend_handle_destroy(struct zn_backend *base)
 {
   struct zn_mock_backend *self = zn_container_of(base, self, base);
@@ -36,6 +40,7 @@ static const struct zn_backend_interface implementation = {
     .create_wlr_texture_from_pixels =
         zn_mock_backend_create_wlr_texture_from_pixels,
     .start = zn_mock_backend_start,
+    .stop = zn_mock_backend_stop,
     .destroy = zn_mock_backend_handle_destroy,
 };
 

--- a/zen/tests/snode/snode-damage.c
+++ b/zen/tests/snode/snode-damage.c
@@ -33,12 +33,12 @@ TEST(general)
   ASSERT_EQUAL_BOOL(
       false, zn_mock_output_damage_contains(output, 50 + 5, 100 + 5));
 
-  zn_snode_set_position(node1, root, 50, 100);
+  zn_snode_set_position(node1, root, (vec2){50, 100});
 
   ASSERT_EQUAL_BOOL(
       true, zn_mock_output_damage_contains(output, 50 + 5, 100 + 5));
 
-  zn_snode_set_position(node2, node1, 80, 10);
+  zn_snode_set_position(node2, node1, (vec2){80, 10});
 
   ASSERT_EQUAL_BOOL(true,
       zn_mock_output_damage_contains(output, 50 + 80 + 15, 100 + 10 + 15));
@@ -50,7 +50,7 @@ TEST(general)
   ASSERT_EQUAL_BOOL(false,
       zn_mock_output_damage_contains(output, 10 + 80 + 15, 20 + 10 + 15));
 
-  zn_snode_set_position(node1, root, 10, 20);
+  zn_snode_set_position(node1, root, (vec2){10, 20});
 
   ASSERT_EQUAL_BOOL(true,
       zn_mock_output_damage_contains(output, 50 + 80 + 15, 100 + 10 + 15));
@@ -75,17 +75,17 @@ TEST(rebase_parent)
   struct zn_snode *node3 = zn_snode_create(&texture, &test_impl);
   struct zn_snode *node4 = zn_snode_create(&texture, &test_impl);
 
-  zn_snode_set_position(node4, node3, 100, 100);
-  zn_snode_set_position(node3, node2, 100, 100);
-  zn_snode_set_position(node2, node1, 100, 100);
-  zn_snode_set_position(node1, root, 100, 100);
+  zn_snode_set_position(node4, node3, (vec2){100, 100});
+  zn_snode_set_position(node3, node2, (vec2){100, 100});
+  zn_snode_set_position(node2, node1, (vec2){100, 100});
+  zn_snode_set_position(node1, root, (vec2){100, 100});
 
   zn_mock_output_damage_clear(output);
 
   ASSERT_EQUAL_BOOL(false, zn_mock_output_damage_contains(output, 405, 405));
   ASSERT_EQUAL_BOOL(false, zn_mock_output_damage_contains(output, 355, 355));
 
-  zn_snode_set_position(node2, root, 150, 150);
+  zn_snode_set_position(node2, root, (vec2){150, 150});
 
   // damages of node4
   ASSERT_EQUAL_BOOL(true, zn_mock_output_damage_contains(output, 405, 405));
@@ -97,7 +97,7 @@ TEST(rebase_parent)
   zn_mock_output_damage_clear(output);
   zn_mock_output_damage_clear(output2);
 
-  zn_snode_set_position(node2, root2, 500, 500);
+  zn_snode_set_position(node2, root2, (vec2){500, 500});
 
   ASSERT_EQUAL_BOOL(true, zn_mock_output_damage_contains(output, 355, 355));
   ASSERT_EQUAL_BOOL(false, zn_mock_output_damage_contains(output, 705, 705));
@@ -109,7 +109,7 @@ TEST(rebase_parent)
    */
   zn_mock_output_damage_clear(output2);
 
-  zn_snode_set_position(node2, NULL, 500, 500);
+  zn_snode_set_position(node2, NULL, (vec2){500, 500});
 
   // damages of node4
   ASSERT_EQUAL_BOOL(true, zn_mock_output_damage_contains(output2, 705, 705));
@@ -120,7 +120,7 @@ TEST(rebase_parent)
   zn_mock_output_damage_clear(output2);
   zn_mock_output_damage_clear(output);
 
-  zn_snode_set_position(node4, node3, 300, 300);
+  zn_snode_set_position(node4, node3, (vec2){300, 300});
 
   // damages of node4
   ASSERT_EQUAL_BOOL(false, pixman_region32_not_empty(&output->damage));

--- a/zen/tests/snode/snode-position.c
+++ b/zen/tests/snode/snode-position.c
@@ -23,12 +23,12 @@ TEST(general)
 
   struct zn_snode *node2 = zn_snode_create(NULL, &test_impl);
 
-  zn_snode_set_position(node1, root, 10.5F, 20.5F);
-  zn_snode_set_position(node11, node1, -4.3F, 3.3F);
-  zn_snode_set_position(node12, node1, 10.3F, -9.9F);
-  zn_snode_set_position(node121, node12, 9.5F, 3.5F);
+  zn_snode_set_position(node1, root, (vec2){10.5F, 20.5F});
+  zn_snode_set_position(node11, node1, (vec2){-4.3F, 3.3F});
+  zn_snode_set_position(node12, node1, (vec2){10.3F, -9.9F});
+  zn_snode_set_position(node121, node12, (vec2){9.5F, 3.5F});
 
-  zn_snode_set_position(node2, root, 9.9F, 3.4F);
+  zn_snode_set_position(node2, root, (vec2){9.9F, 3.4F});
 
   struct wlr_fbox box11;
   struct wlr_fbox box121;
@@ -41,7 +41,7 @@ TEST(general)
   ASSERT_EQUAL_DOUBLE(10.5F + 10.3F + 9.5F, box121.x);
   ASSERT_EQUAL_DOUBLE(20.5F - 9.9F + 3.5F, box121.y);
 
-  zn_snode_set_position(node1, root, 11.6F, -20.6F);
+  zn_snode_set_position(node1, root, (vec2){11.6F, -20.6F});
 
   zn_snode_get_fbox(node11, &box11);
   zn_snode_get_fbox(node121, &box121);
@@ -62,10 +62,10 @@ TEST(parent_change)
   struct zn_snode *node3 = zn_snode_create(NULL, &test_impl);
   struct zn_snode *node4 = zn_snode_create(NULL, &test_impl);
 
-  zn_snode_set_position(node4, node3, 4, 0.4F);
-  zn_snode_set_position(node3, node2, 3, 0.3F);
-  zn_snode_set_position(node2, node1, 2, 0.2F);
-  zn_snode_set_position(node1, root, 1, 0.1F);
+  zn_snode_set_position(node4, node3, (vec2){4, 0.4F});
+  zn_snode_set_position(node3, node2, (vec2){3, 0.3F});
+  zn_snode_set_position(node2, node1, (vec2){2, 0.2F});
+  zn_snode_set_position(node1, root, (vec2){1, 0.1F});
 
   struct wlr_fbox box4;
   zn_snode_get_fbox(node4, &box4);
@@ -73,13 +73,13 @@ TEST(parent_change)
   ASSERT_EQUAL_DOUBLE(1 + 2 + 3 + 4, box4.x);
   ASSERT_EQUAL_DOUBLE(0.1F + 0.2F + 0.3F + 0.4F, box4.y);
 
-  zn_snode_set_position(node2, root, 12, 1.2F);
+  zn_snode_set_position(node2, root, (vec2){12, 1.2F});
   zn_snode_get_fbox(node4, &box4);
 
   ASSERT_EQUAL_DOUBLE(12 + 3 + 4, box4.x);
   ASSERT_EQUAL_DOUBLE(1.2F + 0.3F + 0.4F, box4.y);
 
-  zn_snode_set_position(node2, NULL, 0.0F, 0.0F);
+  zn_snode_set_position(node2, NULL, (vec2){0.0F, 0.0F});
   zn_snode_get_fbox(node4, &box4);
 
   ASSERT_EQUAL_DOUBLE(3 + 4, box4.x);


### PR DESCRIPTION
## Context

Earlier, we implemented screen and screen layout.
Now we can implement the cursor with moving within the screen space, jumping between screens.

## Summary

- [x] Add default grab
- [x] Enable the cursor to move around the screen space.

## How to check the behavior

Start zen-desktop, and move the cursor around.
Multi-screen is supported.