### PR TITLE
Decoration

### DIFF
--- a/desktop/include/zen-desktop/ui/decoration.h
+++ b/desktop/include/zen-desktop/ui/decoration.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cglm/types.h>
+
+struct zn_snode;
+struct zn_ui_header_bar;
+
+struct zn_ui_decoration {
+  struct zn_snode *snode;  // @nonnull, @owning
+
+  vec2 content_size;
+  vec2 content_offset;
+
+  struct zn_ui_header_bar *header_bar;  // @nonnull, @owning
+};
+
+void zn_ui_decoration_set_content_size(
+    struct zn_ui_decoration *self, vec2 size);
+
+struct zn_ui_decoration *zn_ui_decoration_create(void);
+
+void zn_ui_decoration_destroy(struct zn_ui_decoration *self);

--- a/desktop/include/zen-desktop/ui/header-bar.h
+++ b/desktop/include/zen-desktop/ui/header-bar.h
@@ -13,7 +13,7 @@ struct zn_ui_header_bar {
   vec2 size;
 
   struct {
-    struct wl_signal move;
+    struct wl_signal pressed;  // (NULL)
   } events;
 };
 

--- a/desktop/include/zen-desktop/ui/header-bar.h
+++ b/desktop/include/zen-desktop/ui/header-bar.h
@@ -8,6 +8,8 @@ struct zn_snode;
 struct zn_ui_header_bar {
   struct zn_snode *snode;  // @nonnull, @owning
 
+  struct wlr_texture *texture;  // @nullable, @owning
+
   vec2 size;
 
   struct {

--- a/desktop/include/zen-desktop/ui/header-bar.h
+++ b/desktop/include/zen-desktop/ui/header-bar.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cglm/types.h>
+#include <wayland-server-core.h>
+
+struct zn_snode;
+
+struct zn_ui_header_bar {
+  struct zn_snode *snode;  // @nonnull, @owning
+
+  vec2 size;
+
+  struct {
+    struct wl_signal move;
+  } events;
+};
+
+void zn_ui_header_bar_set_size(struct zn_ui_header_bar *self, vec2 size);
+
+struct zn_ui_header_bar *zn_ui_header_bar_create(void);
+
+void zn_ui_header_bar_destroy(struct zn_ui_header_bar *self);

--- a/desktop/include/zen-desktop/view.h
+++ b/desktop/include/zen-desktop/view.h
@@ -14,6 +14,7 @@ struct zn_desktop_view {
 
   struct wl_listener zn_view_unmap_listener;
   struct wl_listener zn_view_request_move_listener;
+  struct wl_listener zn_view_decoration_listener;
   struct wl_listener zn_view_resized_listener;
 
   struct {

--- a/desktop/include/zen-desktop/view.h
+++ b/desktop/include/zen-desktop/view.h
@@ -16,6 +16,7 @@ struct zn_desktop_view {
   struct wl_listener zn_view_request_move_listener;
   struct wl_listener zn_view_decoration_listener;
   struct wl_listener zn_view_resized_listener;
+  struct wl_listener header_pressed_listener;
 
   struct {
     struct wl_signal destroy;

--- a/desktop/include/zen-desktop/view.h
+++ b/desktop/include/zen-desktop/view.h
@@ -4,14 +4,17 @@
 
 struct zn_view;
 struct zn_snode;
+struct zn_ui_decoration;
 
 struct zn_desktop_view {
   struct zn_view *zn_view;  // @nonnull, @outlive
 
-  struct zn_snode *snode;
+  struct zn_snode *snode;               // @nonnull, @owning
+  struct zn_ui_decoration *decoration;  // @nonnull, @owning
 
   struct wl_listener zn_view_unmap_listener;
   struct wl_listener zn_view_move_listener;
+  struct wl_listener zn_view_resized_listener;
 
   struct {
     struct wl_signal destroy;

--- a/desktop/include/zen-desktop/view.h
+++ b/desktop/include/zen-desktop/view.h
@@ -13,7 +13,7 @@ struct zn_desktop_view {
   struct zn_ui_decoration *decoration;  // @nonnull, @owning
 
   struct wl_listener zn_view_unmap_listener;
-  struct wl_listener zn_view_move_listener;
+  struct wl_listener zn_view_request_move_listener;
   struct wl_listener zn_view_resized_listener;
 
   struct {

--- a/desktop/meson.build
+++ b/desktop/meson.build
@@ -2,9 +2,14 @@ _zen_desktop_srcs = [
   'src/cursor-grab.c',
   'src/cursor-grab/default.c',
   'src/cursor-grab/move.c',
+
   'src/screen.c',
   'src/screen-layout.c',
   'src/shell.c',
+
+  'src/ui/decoration.c',
+  'src/ui/header-bar.c',
+
   'src/view.c',
 ]
 

--- a/desktop/meson.build
+++ b/desktop/meson.build
@@ -20,6 +20,8 @@ _zen_desktop_private_inc = [
 ]
 
 _zen_desktop_deps = [
+  cairo_dep,
+  rsvg_dep,
   zen_common_dep,
   zen_dep,
 ]

--- a/desktop/src/ui/decoration.c
+++ b/desktop/src/ui/decoration.c
@@ -1,0 +1,77 @@
+#include "zen-desktop/ui/decoration.h"
+
+#include <cglm/vec2.h>
+#include <zen-common/log.h>
+#include <zen-common/util.h>
+
+#include "zen-desktop/ui/header-bar.h"
+#include "zen/snode.h"
+
+#define HEADER_HEIGHT 30
+
+static const struct zn_snode_interface snode_implementation = {
+    .get_texture = zn_snode_noop_get_texture,
+    .frame = zn_snode_noop_frame,
+    .accepts_input = zn_snode_noop_accepts_input,
+    .pointer_button = zn_snode_noop_pointer_button,
+    .pointer_enter = zn_snode_noop_pointer_enter,
+    .pointer_motion = zn_snode_noop_pointer_motion,
+    .pointer_leave = zn_snode_noop_pointer_leave,
+    .pointer_axis = zn_snode_noop_pointer_axis,
+    .pointer_frame = zn_snode_noop_pointer_frame,
+};
+
+void
+zn_ui_decoration_set_content_size(struct zn_ui_decoration *self, vec2 size)
+{
+  zn_ui_header_bar_set_size(self->header_bar, (vec2){size[0], HEADER_HEIGHT});
+
+  glm_vec2_copy(size, self->content_size);
+  glm_vec2_copy((vec2){0, HEADER_HEIGHT}, self->content_offset);
+}
+
+struct zn_ui_decoration *
+zn_ui_decoration_create(void)
+{
+  struct zn_ui_decoration *self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  glm_vec2_copy(GLM_VEC2_ZERO, self->content_size);
+  glm_vec2_copy(GLM_VEC2_ZERO, self->content_offset);
+
+  self->snode = zn_snode_create(self, &snode_implementation);
+  if (self->snode == NULL) {
+    zn_error("Failed to create a snode");
+    goto err_free;
+  }
+
+  self->header_bar = zn_ui_header_bar_create();
+  if (self->header_bar == NULL) {
+    zn_error("Failed to create a zn_ui_header_bar");
+    goto err_snode;
+  }
+
+  zn_snode_set_position(self->header_bar->snode, self->snode, GLM_VEC2_ZERO);
+
+  return self;
+
+err_snode:
+  zn_snode_destroy(self->snode);
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+void
+zn_ui_decoration_destroy(struct zn_ui_decoration *self)
+{
+  zn_ui_header_bar_destroy(self->header_bar);
+  zn_snode_destroy(self->snode);
+  free(self);
+}

--- a/desktop/src/ui/header-bar.c
+++ b/desktop/src/ui/header-bar.c
@@ -1,13 +1,24 @@
 #include "zen-desktop/ui/header-bar.h"
 
+#include <cairo.h>
 #include <cglm/vec2.h>
+#include <drm_fourcc.h>
 #include <zen-common/log.h>
 #include <zen-common/util.h>
 
+#include "zen/backend.h"
+#include "zen/server.h"
 #include "zen/snode.h"
 
+struct wlr_texture *
+zn_ui_header_bar_get_texture(void *user_data)
+{
+  struct zn_ui_header_bar *self = user_data;
+  return self->texture;
+}
+
 static const struct zn_snode_interface snode_implementation = {
-    .get_texture = zn_snode_noop_get_texture,
+    .get_texture = zn_ui_header_bar_get_texture,
     .frame = zn_snode_noop_frame,
     .accepts_input = zn_snode_noop_accepts_input,
     .pointer_button = zn_snode_noop_pointer_button,
@@ -18,10 +29,66 @@ static const struct zn_snode_interface snode_implementation = {
     .pointer_frame = zn_snode_noop_pointer_frame,
 };
 
+static void
+zn_ui_header_bar_render(struct zn_ui_header_bar *self, cairo_t *cr)
+{
+  float r = 5.F;
+  float w = self->size[0];
+  float h = self->size[1];
+  cairo_set_source_rgba(cr, 0.8, 0.8, 0.8, 1.0);
+
+  cairo_move_to(cr, 0, h);
+  cairo_line_to(cr, 0, r);
+  cairo_arc(cr, r, r, r, -M_PI, -M_PI_2);
+  cairo_line_to(cr, w - r, 0);
+  cairo_arc(cr, w - r, r, r, -M_PI_2, 0);
+  cairo_line_to(cr, w, h);
+  cairo_line_to(cr, 0, h);
+
+  cairo_fill(cr);
+}
+
 void
 zn_ui_header_bar_set_size(struct zn_ui_header_bar *self, vec2 size)
 {
+  struct zn_server *server = zn_server_get_singleton();
+
   glm_vec2_copy(size, self->size);
+
+  cairo_surface_t *surface = cairo_image_surface_create(
+      CAIRO_FORMAT_ARGB32, (int)size[0], (int)size[1]);
+  if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+    zn_abort("Failed to create a cairo surface");
+    goto out;
+  }
+
+  cairo_t *cr = cairo_create(surface);
+  if (cairo_status(cr) != CAIRO_STATUS_SUCCESS) {
+    zn_abort("Failed to create a cairo context");
+    goto out_cairo;
+  }
+
+  zn_ui_header_bar_render(self, cr);
+
+  if (self->texture) {
+    zn_snode_damage_whole(self->snode);
+    wlr_texture_destroy(self->texture);
+  }
+
+  unsigned char *data = cairo_image_surface_get_data(surface);
+  int stride = cairo_image_surface_get_stride(surface);
+  int width = cairo_image_surface_get_width(surface);
+  int height = cairo_image_surface_get_height(surface);
+  self->texture = zn_backend_create_wlr_texture_from_pixels(
+      server->backend, DRM_FORMAT_ARGB8888, stride, width, height, data);
+
+  zn_snode_damage_whole(self->snode);
+
+out_cairo:
+  cairo_destroy(cr);
+
+out:
+  cairo_surface_destroy(surface);
 }
 
 struct zn_ui_header_bar *
@@ -42,6 +109,8 @@ zn_ui_header_bar_create(void)
   glm_vec2_copy(GLM_VEC2_ZERO, self->size);
   wl_signal_init(&self->events.move);
 
+  self->texture = NULL;
+
   return self;
 
 err_free:
@@ -54,6 +123,11 @@ err:
 void
 zn_ui_header_bar_destroy(struct zn_ui_header_bar *self)
 {
+  zn_snode_damage_whole(self->snode);
+
+  if (self->texture) {
+    wlr_texture_destroy(self->texture);
+  }
   wl_list_remove(&self->events.move.listener_list);
   zn_snode_destroy(self->snode);
   free(self);

--- a/desktop/src/ui/header-bar.c
+++ b/desktop/src/ui/header-bar.c
@@ -17,11 +17,30 @@ zn_ui_header_bar_get_texture(void *user_data)
   return self->texture;
 }
 
+static bool
+zn_ui_header_accepts_input(void *user_data, const vec2 point)
+{
+  struct zn_ui_header_bar *self = user_data;
+  return 0 <= point[0] && point[0] <= self->size[0] && 0 <= point[1] &&
+         point[1] <= self->size[1];
+}
+
+static void
+zn_ui_header_pointer_button(void *user_data, uint32_t time_msec UNUSED,
+    uint32_t button UNUSED, enum wlr_button_state state)
+{
+  struct zn_ui_header_bar *self = user_data;
+
+  if (state == WLR_BUTTON_PRESSED) {
+    wl_signal_emit(&self->events.pressed, NULL);
+  }
+}
+
 static const struct zn_snode_interface snode_implementation = {
     .get_texture = zn_ui_header_bar_get_texture,
     .frame = zn_snode_noop_frame,
-    .accepts_input = zn_snode_noop_accepts_input,
-    .pointer_button = zn_snode_noop_pointer_button,
+    .accepts_input = zn_ui_header_accepts_input,
+    .pointer_button = zn_ui_header_pointer_button,
     .pointer_enter = zn_snode_noop_pointer_enter,
     .pointer_motion = zn_snode_noop_pointer_motion,
     .pointer_leave = zn_snode_noop_pointer_leave,
@@ -107,7 +126,7 @@ zn_ui_header_bar_create(void)
   }
 
   glm_vec2_copy(GLM_VEC2_ZERO, self->size);
-  wl_signal_init(&self->events.move);
+  wl_signal_init(&self->events.pressed);
 
   self->texture = NULL;
 
@@ -128,7 +147,7 @@ zn_ui_header_bar_destroy(struct zn_ui_header_bar *self)
   if (self->texture) {
     wlr_texture_destroy(self->texture);
   }
-  wl_list_remove(&self->events.move.listener_list);
+  wl_list_remove(&self->events.pressed.listener_list);
   zn_snode_destroy(self->snode);
   free(self);
 }

--- a/desktop/src/ui/header-bar.c
+++ b/desktop/src/ui/header-bar.c
@@ -1,0 +1,60 @@
+#include "zen-desktop/ui/header-bar.h"
+
+#include <cglm/vec2.h>
+#include <zen-common/log.h>
+#include <zen-common/util.h>
+
+#include "zen/snode.h"
+
+static const struct zn_snode_interface snode_implementation = {
+    .get_texture = zn_snode_noop_get_texture,
+    .frame = zn_snode_noop_frame,
+    .accepts_input = zn_snode_noop_accepts_input,
+    .pointer_button = zn_snode_noop_pointer_button,
+    .pointer_enter = zn_snode_noop_pointer_enter,
+    .pointer_motion = zn_snode_noop_pointer_motion,
+    .pointer_leave = zn_snode_noop_pointer_leave,
+    .pointer_axis = zn_snode_noop_pointer_axis,
+    .pointer_frame = zn_snode_noop_pointer_frame,
+};
+
+void
+zn_ui_header_bar_set_size(struct zn_ui_header_bar *self, vec2 size)
+{
+  glm_vec2_copy(size, self->size);
+}
+
+struct zn_ui_header_bar *
+zn_ui_header_bar_create(void)
+{
+  struct zn_ui_header_bar *self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->snode = zn_snode_create(self, &snode_implementation);
+  if (self->snode == NULL) {
+    zn_error("Failed to create a snode");
+    goto err_free;
+  }
+
+  glm_vec2_copy(GLM_VEC2_ZERO, self->size);
+  wl_signal_init(&self->events.move);
+
+  return self;
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+void
+zn_ui_header_bar_destroy(struct zn_ui_header_bar *self)
+{
+  wl_list_remove(&self->events.move.listener_list);
+  zn_snode_destroy(self->snode);
+  free(self);
+}

--- a/desktop/src/view.c
+++ b/desktop/src/view.c
@@ -6,10 +6,23 @@
 #include "zen-common/signal.h"
 #include "zen-common/util.h"
 #include "zen-desktop/cursor-grab/move.h"
+#include "zen-desktop/ui/decoration.h"
 #include "zen/snode.h"
 #include "zen/view.h"
 
 static void zn_desktop_view_destroy(struct zn_desktop_view *self);
+
+static void
+zn_desktop_view_handle_zn_view_resized(
+    struct wl_listener *listener, void *user_data UNUSED)
+{
+  struct zn_desktop_view *self =
+      zn_container_of(listener, self, zn_view_resized_listener);
+
+  zn_ui_decoration_set_content_size(self->decoration, self->zn_view->size);
+  zn_snode_set_position(
+      self->zn_view->snode, self->snode, self->decoration->content_offset);
+}
 
 static void
 zn_desktop_view_handle_zn_view_move(
@@ -48,15 +61,32 @@ zn_desktop_view_create(struct zn_view *zn_view)
     goto err_free;
   }
 
+  self->decoration = zn_ui_decoration_create();
+  if (self->decoration == NULL) {
+    zn_error("Failed to create a zn_ui_decoration");
+    goto err_snode;
+  }
+
+  self->zn_view_resized_listener.notify =
+      zn_desktop_view_handle_zn_view_resized;
+  wl_signal_add(&zn_view->events.resized, &self->zn_view_resized_listener);
+
   self->zn_view_unmap_listener.notify = zn_desktop_view_handle_zn_view_unmap;
   wl_signal_add(&zn_view->events.unmap, &self->zn_view_unmap_listener);
 
   self->zn_view_move_listener.notify = zn_desktop_view_handle_zn_view_move;
   wl_signal_add(&zn_view->events.move, &self->zn_view_move_listener);
 
-  zn_snode_set_position(zn_view->snode, self->snode, GLM_VEC2_ZERO);
+  zn_snode_set_position(self->decoration->snode, self->snode, GLM_VEC2_ZERO);
+
+  zn_ui_decoration_set_content_size(self->decoration, zn_view->size);
+  zn_snode_set_position(
+      zn_view->snode, self->snode, self->decoration->content_offset);
 
   return self;
+
+err_snode:
+  zn_snode_destroy(self->snode);
 
 err_free:
   free(self);
@@ -70,9 +100,11 @@ zn_desktop_view_destroy(struct zn_desktop_view *self)
 {
   zn_signal_emit_mutable(&self->events.destroy, NULL);
 
+  zn_ui_decoration_destroy(self->decoration);
   zn_snode_destroy(self->snode);
   wl_list_remove(&self->zn_view_move_listener.link);
   wl_list_remove(&self->zn_view_unmap_listener.link);
+  wl_list_remove(&self->zn_view_resized_listener.link);
   wl_list_remove(&self->events.destroy.listener_list);
   free(self);
 }

--- a/desktop/src/view.c
+++ b/desktop/src/view.c
@@ -7,6 +7,7 @@
 #include "zen-common/util.h"
 #include "zen-desktop/cursor-grab/move.h"
 #include "zen-desktop/ui/decoration.h"
+#include "zen-desktop/ui/header-bar.h"
 #include "zen/snode.h"
 #include "zen/view.h"
 
@@ -26,6 +27,16 @@ zn_desktop_view_update_decoration(struct zn_desktop_view *self)
     zn_snode_set_position(
         self->zn_view->snode, self->snode, self->decoration->content_offset);
   }
+}
+
+static void
+zn_desktop_view_handle_header_pressed(
+    struct wl_listener *listener, void *user_data UNUSED)
+{
+  struct zn_desktop_view *self =
+      zn_container_of(listener, self, header_pressed_listener);
+
+  zn_cursor_move_grab_start(self);
 }
 
 static void
@@ -91,6 +102,10 @@ zn_desktop_view_create(struct zn_view *zn_view)
     goto err_snode;
   }
 
+  self->header_pressed_listener.notify = zn_desktop_view_handle_header_pressed;
+  wl_signal_add(&self->decoration->header_bar->events.pressed,
+      &self->header_pressed_listener);
+
   self->zn_view_resized_listener.notify =
       zn_desktop_view_handle_zn_view_resized;
   wl_signal_add(&zn_view->events.resized, &self->zn_view_resized_listener);
@@ -133,6 +148,7 @@ zn_desktop_view_destroy(struct zn_desktop_view *self)
   wl_list_remove(&self->zn_view_request_move_listener.link);
   wl_list_remove(&self->zn_view_unmap_listener.link);
   wl_list_remove(&self->zn_view_resized_listener.link);
+  wl_list_remove(&self->header_pressed_listener.link);
   wl_list_remove(&self->events.destroy.listener_list);
   free(self);
 }

--- a/desktop/src/view.c
+++ b/desktop/src/view.c
@@ -29,7 +29,7 @@ zn_desktop_view_handle_zn_view_move(
     struct wl_listener *listener, void *user_data UNUSED)
 {
   struct zn_desktop_view *self =
-      zn_container_of(listener, self, zn_view_move_listener);
+      zn_container_of(listener, self, zn_view_request_move_listener);
   zn_cursor_move_grab_start(self);
 }
 
@@ -74,8 +74,10 @@ zn_desktop_view_create(struct zn_view *zn_view)
   self->zn_view_unmap_listener.notify = zn_desktop_view_handle_zn_view_unmap;
   wl_signal_add(&zn_view->events.unmap, &self->zn_view_unmap_listener);
 
-  self->zn_view_move_listener.notify = zn_desktop_view_handle_zn_view_move;
-  wl_signal_add(&zn_view->events.move, &self->zn_view_move_listener);
+  self->zn_view_request_move_listener.notify =
+      zn_desktop_view_handle_zn_view_move;
+  wl_signal_add(
+      &zn_view->events.request_move, &self->zn_view_request_move_listener);
 
   zn_snode_set_position(self->decoration->snode, self->snode, GLM_VEC2_ZERO);
 
@@ -102,7 +104,7 @@ zn_desktop_view_destroy(struct zn_desktop_view *self)
 
   zn_ui_decoration_destroy(self->decoration);
   zn_snode_destroy(self->snode);
-  wl_list_remove(&self->zn_view_move_listener.link);
+  wl_list_remove(&self->zn_view_request_move_listener.link);
   wl_list_remove(&self->zn_view_unmap_listener.link);
   wl_list_remove(&self->zn_view_resized_listener.link);
   wl_list_remove(&self->events.destroy.listener_list);

--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ glew_proj = subproject(
   version: '2.2.0',
 )
 
-
+cairo_dep = dependency('cairo')
 cglm_dep = dependency('cglm')
 drm_dep = dependency('libdrm')
 egl_dep = dependency('egl')
@@ -119,6 +119,7 @@ gl_dep = dependency('gl')
 glew_dep = glew_proj.get_variable('glew_dep')
 m_dep = cc.find_library('m')
 pixman_dep = dependency('pixman-1')
+rsvg_dep = dependency('librsvg-2.0')
 wayland_server_dep = dependency('wayland-server', version: wayland_req)
 wlroots_dep = dependency('wlroots', version: wlroots_req)
 

--- a/zen/include/zen/snode.h
+++ b/zen/include/zen/snode.h
@@ -16,14 +16,14 @@ struct zn_snode_interface {
 
   /// @return true if `point` is in input region
   /// @param point is in snode-local coords
-  bool (*accepts_input)(void *user_data, vec2 point);
+  bool (*accepts_input)(void *user_data, const vec2 point);
 
   void (*pointer_button)(void *user_data, uint32_t time_msec, uint32_t button,
       enum wlr_button_state state);
 
-  void (*pointer_enter)(void *user_data, vec2 point);
+  void (*pointer_enter)(void *user_data, const vec2 point);
 
-  void (*pointer_motion)(void *user_data, uint32_t time_msec, vec2 point);
+  void (*pointer_motion)(void *user_data, uint32_t time_msec, const vec2 point);
 
   void (*pointer_leave)(void *user_data);
 
@@ -40,15 +40,15 @@ struct wlr_texture *zn_snode_noop_get_texture(void *user_data);
 
 void zn_snode_noop_frame(void *user_data, const struct timespec *when);
 
-bool zn_snode_noop_accepts_input(void *user_data, vec2 point);
+bool zn_snode_noop_accepts_input(void *user_data, const vec2 point);
 
 void zn_snode_noop_pointer_button(void *user_data, uint32_t time_msec,
     uint32_t button, enum wlr_button_state state);
 
-void zn_snode_noop_pointer_enter(void *user_data, vec2 point);
+void zn_snode_noop_pointer_enter(void *user_data, const vec2 point);
 
 void zn_snode_noop_pointer_motion(
-    void *user_data, uint32_t time_msec, vec2 point);
+    void *user_data, uint32_t time_msec, const vec2 point);
 
 void zn_snode_noop_pointer_leave(void *user_data);
 
@@ -94,13 +94,14 @@ zn_snode_pointer_button(struct zn_snode *self, uint32_t time_msec,
 }
 
 UNUSED static inline void
-zn_snode_pointer_enter(struct zn_snode *self, vec2 point)
+zn_snode_pointer_enter(struct zn_snode *self, const vec2 point)
 {
   self->impl->pointer_enter(self->user_data, point);
 }
 
 UNUSED static inline void
-zn_snode_pointer_motion(struct zn_snode *self, uint32_t time_msec, vec2 point)
+zn_snode_pointer_motion(
+    struct zn_snode *self, uint32_t time_msec, const vec2 point)
 {
   self->impl->pointer_motion(self->user_data, time_msec, point);
 }

--- a/zen/include/zen/snode.h
+++ b/zen/include/zen/snode.h
@@ -137,6 +137,8 @@ zn_snode_pointer_frame(struct zn_snode *self)
 struct zn_snode *zn_snode_get_snode_at(
     struct zn_snode *self, vec2 point, vec2 local_point);
 
+void zn_snode_damage_whole(struct zn_snode *self);
+
 /// @param damage is in the snode-local coords
 void zn_snode_damage(struct zn_snode *self, struct wlr_fbox *damage);
 

--- a/zen/include/zen/view.h
+++ b/zen/include/zen/view.h
@@ -17,9 +17,9 @@ struct zn_view {
   struct zn_snode *snode;  // @nonnull, @owning
 
   struct {
-    struct wl_signal resized;  // (NULL)
-    struct wl_signal unmap;    // (NULL)
-    struct wl_signal move;     // (NULL)
+    struct wl_signal resized;       // (NULL)
+    struct wl_signal unmap;         // (NULL)
+    struct wl_signal request_move;  // (NULL)
   } events;
 };
 
@@ -27,7 +27,7 @@ struct zn_view {
 void zn_view_notify_resized(struct zn_view *self, vec2 size);
 
 /// Called by the impl object
-void zn_view_notify_move(struct zn_view *self);
+void zn_view_notify_move_request(struct zn_view *self);
 
 /// Called by the impl object
 void zn_view_notify_unmap(struct zn_view *self);

--- a/zen/include/zen/view.h
+++ b/zen/include/zen/view.h
@@ -8,23 +8,38 @@ struct zn_view_interface {
   void (*set_activated)(void *impl_data, bool activate);
 };
 
+enum zn_view_decoration_mode {
+  ZN_VIEW_DECORATION_MODE_SERVER_SIDE = 0,
+  ZN_VIEW_DECORATION_MODE_CLIENT_SIDE = 1,
+};
+
 struct zn_view {
   void *impl_data;                       // @nullable, @outlive if exists
   const struct zn_view_interface *impl;  // @nonnull, @outlive
 
   vec2 size;
 
+  /// TODO(@Aki-7): The decoration mode is determined by the zen component.
+  /// Considering Wayland apps, the user should be able to declare a preferred
+  /// mode, and zen should respect the preferred mode as much as possible.
+  enum zn_view_decoration_mode decoration_mode;
+
   struct zn_snode *snode;  // @nonnull, @owning
 
   struct {
     struct wl_signal resized;       // (NULL)
     struct wl_signal unmap;         // (NULL)
+    struct wl_signal decoration;    // (NULL)
     struct wl_signal request_move;  // (NULL)
   } events;
 };
 
 /// Called by the impl object
 void zn_view_notify_resized(struct zn_view *self, vec2 size);
+
+/// Called by the impl object
+void zn_view_notify_decoration(
+    struct zn_view *self, enum zn_view_decoration_mode mode);
 
 /// Called by the impl object
 void zn_view_notify_move_request(struct zn_view *self);

--- a/zen/include/zen/view.h
+++ b/zen/include/zen/view.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cglm/types.h>
 #include <stdbool.h>
 #include <wayland-server-core.h>
 
@@ -11,13 +12,19 @@ struct zn_view {
   void *impl_data;                       // @nullable, @outlive if exists
   const struct zn_view_interface *impl;  // @nonnull, @outlive
 
+  vec2 size;
+
   struct zn_snode *snode;  // @nonnull, @owning
 
   struct {
-    struct wl_signal unmap;  // (NULL)
-    struct wl_signal move;   // (NULL)
+    struct wl_signal resized;  // (NULL)
+    struct wl_signal unmap;    // (NULL)
+    struct wl_signal move;     // (NULL)
   } events;
 };
+
+/// Called by the impl object
+void zn_view_notify_resized(struct zn_view *self, vec2 size);
 
 /// Called by the impl object
 void zn_view_notify_move(struct zn_view *self);

--- a/zen/src/backend/xwayland-surface.c
+++ b/zen/src/backend/xwayland-surface.c
@@ -130,7 +130,7 @@ zn_xwayland_surface_handle_move(struct wl_listener *listener, void *data UNUSED)
   struct zn_xwayland_surface *self =
       zn_container_of(listener, self, surface_move_listener);
 
-  zn_view_notify_move(self->view);
+  zn_view_notify_move_request(self->view);
 }
 
 static void

--- a/zen/src/backend/xwayland-surface.c
+++ b/zen/src/backend/xwayland-surface.c
@@ -26,7 +26,7 @@ zn_xwayland_surface_handle_frame(void *user_data, const struct timespec *when)
 }
 
 static bool
-zn_xwayland_surface_accepts_input(void *user_data, vec2 point)
+zn_xwayland_surface_accepts_input(void *user_data, const vec2 point)
 {
   struct zn_xwayland_surface *self = user_data;
   return wlr_surface_point_accepts_input(
@@ -43,7 +43,7 @@ zn_xwayland_surface_handle_pointer_button(void *user_data UNUSED,
 }
 
 static void
-zn_xwayland_surface_handle_pointer_enter(void *user_data, vec2 point)
+zn_xwayland_surface_handle_pointer_enter(void *user_data, const vec2 point)
 {
   struct zn_xwayland_surface *self = user_data;
   struct zn_server *server = zn_server_get_singleton();
@@ -53,7 +53,7 @@ zn_xwayland_surface_handle_pointer_enter(void *user_data, vec2 point)
 
 static void
 zn_xwayland_surface_handle_pointer_motion(
-    void *user_data UNUSED, uint32_t time_msec, vec2 point)
+    void *user_data UNUSED, uint32_t time_msec, const vec2 point)
 {
   struct zn_server *server = zn_server_get_singleton();
   wlr_seat_pointer_send_motion(

--- a/zen/src/backend/xwayland-surface.c
+++ b/zen/src/backend/xwayland-surface.c
@@ -183,6 +183,14 @@ zn_xwayland_surface_handle_commit(
   }
 
   pixman_region32_fini(&damage);
+
+  vec2 new_size = {(float)self->wlr_xsurface->surface->current.width,
+      (float)self->wlr_xsurface->surface->current.height};
+
+  if (self->view->size[0] != new_size[0] ||
+      self->view->size[1] != new_size[1]) {
+    zn_view_notify_resized(self->view, new_size);
+  }
 }
 
 static void
@@ -206,6 +214,9 @@ zn_xwayland_surface_handle_surface_map(
 
   wl_signal_add(&self->wlr_xsurface->surface->events.commit,
       &self->surface_commit_listener);
+
+  zn_view_notify_resized(self->view,
+      (vec2){self->wlr_xsurface->width, self->wlr_xsurface->height});
 
   zn_default_backend_notify_view_mapped(backend, self->view);
 }

--- a/zen/src/backend/xwayland-surface.h
+++ b/zen/src/backend/xwayland-surface.h
@@ -18,6 +18,7 @@ struct zn_xwayland_surface {
   struct wl_listener surface_unmap_listener;
   struct wl_listener surface_configure_listener;
   struct wl_listener surface_move_listener;
+  struct wl_listener surface_set_decoration_listener;
   struct wl_listener surface_commit_listener;  // listen only when mapped
 
   struct wl_listener snode_position_changed_listener;

--- a/zen/src/snode.c
+++ b/zen/src/snode.c
@@ -64,7 +64,7 @@ const struct zn_snode_interface zn_snode_noop_implementation = {
     .pointer_frame = zn_snode_noop_pointer_frame,
 };
 
-static void
+void
 zn_snode_damage_whole(struct zn_snode *self)
 {
   struct wlr_fbox box;

--- a/zen/src/snode.c
+++ b/zen/src/snode.c
@@ -18,7 +18,7 @@ zn_snode_noop_frame(void *user_data UNUSED, const struct timespec *when UNUSED)
 {}
 
 bool
-zn_snode_noop_accepts_input(void *user_data UNUSED, vec2 point UNUSED)
+zn_snode_noop_accepts_input(void *user_data UNUSED, const vec2 point UNUSED)
 {
   return false;
 }
@@ -29,12 +29,12 @@ zn_snode_noop_pointer_button(void *user_data UNUSED, uint32_t time_msec UNUSED,
 {}
 
 void
-zn_snode_noop_pointer_enter(void *user_data UNUSED, vec2 point UNUSED)
+zn_snode_noop_pointer_enter(void *user_data UNUSED, const vec2 point UNUSED)
 {}
 
 void
 zn_snode_noop_pointer_motion(
-    void *user_data UNUSED, uint32_t time_msec UNUSED, vec2 point UNUSED)
+    void *user_data UNUSED, uint32_t time_msec UNUSED, const vec2 point UNUSED)
 {}
 
 void

--- a/zen/src/view.c
+++ b/zen/src/view.c
@@ -1,8 +1,17 @@
 #include "zen/view.h"
 
+#include <cglm/vec2.h>
+
 #include "zen-common/log.h"
 #include "zen-common/util.h"
 #include "zen/snode.h"
+
+void
+zn_view_notify_resized(struct zn_view *self, vec2 size)
+{
+  glm_vec2_copy(size, self->size);
+  wl_signal_emit(&self->events.resized, NULL);
+}
 
 void
 zn_view_notify_move(struct zn_view *self)
@@ -36,6 +45,7 @@ zn_view_create(void *impl_data, const struct zn_view_interface *implementation)
   self->impl_data = impl_data;
   self->impl = implementation;
 
+  wl_signal_init(&self->events.resized);
   wl_signal_init(&self->events.unmap);
   wl_signal_init(&self->events.move);
 
@@ -51,6 +61,7 @@ err:
 void
 zn_view_destroy(struct zn_view *self)
 {
+  wl_list_remove(&self->events.resized.listener_list);
   wl_list_remove(&self->events.unmap.listener_list);
   wl_list_remove(&self->events.move.listener_list);
   zn_snode_destroy(self->snode);

--- a/zen/src/view.c
+++ b/zen/src/view.c
@@ -14,9 +14,9 @@ zn_view_notify_resized(struct zn_view *self, vec2 size)
 }
 
 void
-zn_view_notify_move(struct zn_view *self)
+zn_view_notify_move_request(struct zn_view *self)
 {
-  wl_signal_emit(&self->events.move, NULL);
+  wl_signal_emit(&self->events.request_move, NULL);
 }
 
 void
@@ -47,7 +47,7 @@ zn_view_create(void *impl_data, const struct zn_view_interface *implementation)
 
   wl_signal_init(&self->events.resized);
   wl_signal_init(&self->events.unmap);
-  wl_signal_init(&self->events.move);
+  wl_signal_init(&self->events.request_move);
 
   return self;
 
@@ -63,7 +63,7 @@ zn_view_destroy(struct zn_view *self)
 {
   wl_list_remove(&self->events.resized.listener_list);
   wl_list_remove(&self->events.unmap.listener_list);
-  wl_list_remove(&self->events.move.listener_list);
+  wl_list_remove(&self->events.request_move.listener_list);
   zn_snode_destroy(self->snode);
   free(self);
 }

--- a/zen/src/view.c
+++ b/zen/src/view.c
@@ -14,6 +14,14 @@ zn_view_notify_resized(struct zn_view *self, vec2 size)
 }
 
 void
+zn_view_notify_decoration(
+    struct zn_view *self, enum zn_view_decoration_mode mode)
+{
+  self->decoration_mode = mode;
+  wl_signal_emit(&self->events.decoration, NULL);
+}
+
+void
 zn_view_notify_move_request(struct zn_view *self)
 {
   wl_signal_emit(&self->events.request_move, NULL);
@@ -44,9 +52,11 @@ zn_view_create(void *impl_data, const struct zn_view_interface *implementation)
 
   self->impl_data = impl_data;
   self->impl = implementation;
+  self->decoration_mode = ZN_VIEW_DECORATION_MODE_SERVER_SIDE;
 
   wl_signal_init(&self->events.resized);
   wl_signal_init(&self->events.unmap);
+  wl_signal_init(&self->events.decoration);
   wl_signal_init(&self->events.request_move);
 
   return self;
@@ -63,6 +73,7 @@ zn_view_destroy(struct zn_view *self)
 {
   wl_list_remove(&self->events.resized.listener_list);
   wl_list_remove(&self->events.unmap.listener_list);
+  wl_list_remove(&self->events.decoration.listener_list);
   wl_list_remove(&self->events.request_move.listener_list);
   zn_snode_destroy(self->snode);
   free(self);

--- a/zen/tests/snode/snode-get-at.c
+++ b/zen/tests/snode/snode-get-at.c
@@ -8,7 +8,7 @@
 #include "zen/snode.h"
 
 bool
-test_accepts_input(void *user_data UNUSED, vec2 point UNUSED)
+test_accepts_input(void *user_data UNUSED, const vec2 point UNUSED)
 {
   struct wlr_fbox *box = user_data;
   return zn_wlr_fbox_contains_point(box, point[0], point[1]);


### PR DESCRIPTION
## Context

Render decoration if needed to move views around.
Resizing is not the scope of this PR.

## Summary

- [x] Add snode for decoration 73ce9ed03228c32588da394a6ad50694e6030cb1
- [x] Rename move request `move` -> `request_move` e56567790255c91e89791d61c18c6efb96fbfe05
- [x] Add a signal to detect decoration mode change. 503ef8a41d9d4b011d90d8c3d723327ddcad7aa1
- [x] Render header bar with cairo 1c026088a450f51d566f07a33ee49c2bb6a59b5f
- [x] Enable to move xwayland view with decoration header 28389f78997087a10364c9aa310c1e33e9ad8d9f

## How to check the behavior

Move x apps.
