### PR TITLE
Fix #385

### DIFF
--- a/desktop/include/zen-desktop/screen.h
+++ b/desktop/include/zen-desktop/screen.h
@@ -6,7 +6,6 @@
 struct zn_screen;
 
 struct zn_desktop_screen {
-  vec2 position;             // layout coords
   struct zn_screen *screen;  // @nonnull, @outlive
 
   struct zn_snode *cursor_layer;  // @nonnull, @owning
@@ -17,6 +16,9 @@ struct zn_desktop_screen {
   struct wl_listener screen_resized_listener;
   struct wl_listener screen_destroy_listener;
 };
+
+void zn_desktop_screen_set_position(
+    struct zn_desktop_screen *self, vec2 position);
 
 void zn_desktop_screen_effective_to_layout_coords(
     struct zn_desktop_screen *self, vec2 effective, vec2 layout);

--- a/desktop/src/screen-layout.c
+++ b/desktop/src/screen-layout.c
@@ -31,8 +31,8 @@ zn_screen_layout_get_closest_position(struct zn_screen_layout *self,
 
     // layout coords
     struct wlr_fbox screen_fbox = {
-        .x = desktop_screen_iter->position[0],
-        .y = desktop_screen_iter->position[1],
+        .x = desktop_screen_iter->screen->layout_position[0],
+        .y = desktop_screen_iter->screen->layout_position[1],
         .width = desktop_screen_iter->screen->size[0],
         .height = desktop_screen_iter->screen->size[1],
     };
@@ -46,7 +46,7 @@ zn_screen_layout_get_closest_position(struct zn_screen_layout *self,
     if (current_closest_distance < closest_distance) {
       closest_distance = current_closest_distance;
       glm_vec2_sub((vec2){(float)current_closest_x, (float)current_closest_y},
-          desktop_screen_iter->position, position_out);
+          desktop_screen_iter->screen->layout_position, position_out);
       *desktop_screen_out = desktop_screen_iter;
     }
   }
@@ -70,12 +70,11 @@ void
 zn_screen_layout_reposition(struct zn_screen_layout *self)
 {
   // TODO(@Aki-7): it's a naive implementation
-  float x = 0;
+  vec2 position = GLM_VEC2_ZERO_INIT;
   struct zn_desktop_screen *desktop_screen = NULL;
   wl_list_for_each (desktop_screen, &self->desktop_screen_list, link) {
-    desktop_screen->position[0] = x;
-    desktop_screen->position[1] = 0;
-    x += desktop_screen->screen->size[0];
+    zn_desktop_screen_set_position(desktop_screen, position);
+    position[0] += desktop_screen->screen->size[0];
   }
 }
 

--- a/desktop/src/screen.c
+++ b/desktop/src/screen.c
@@ -33,10 +33,16 @@ zn_desktop_screen_handle_screen_resize(
 }
 
 void
+zn_desktop_screen_set_position(struct zn_desktop_screen *self, vec2 position)
+{
+  zn_screen_set_layout_position(self->screen, position);
+}
+
+void
 zn_desktop_screen_effective_to_layout_coords(
     struct zn_desktop_screen *self, vec2 effective, vec2 layout)
 {
-  glm_vec2_add(self->position, effective, layout);
+  glm_vec2_add(self->screen->layout_position, effective, layout);
 }
 
 struct zn_desktop_screen *
@@ -54,7 +60,6 @@ zn_desktop_screen_create(struct zn_screen *screen)
     goto err;
   }
 
-  glm_vec2_zero(self->position);
   wl_list_init(&self->link);
   self->screen = screen;
   screen->user_data = self;

--- a/desktop/tests/screen-layout/layout.c
+++ b/desktop/tests/screen-layout/layout.c
@@ -32,21 +32,22 @@ TEST(add_remove_output)
   zn_screen_layout_add(shell->screen_layout, desktop_screen3);
   zn_screen_layout_add(shell->screen_layout, desktop_screen4);
 
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 720, desktop_screen3->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 720 + 1280, desktop_screen4->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->position[1]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920 + 720, desktop_screen3->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(
+      1920 + 720 + 1280, desktop_screen4->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->screen->layout_position[1]);
 
   zn_mock_output_destroy(output2);
 
-  ASSERT_EQUAL_DOUBLE(1920, desktop_screen3->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 1280, desktop_screen4->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->position[1]);
+  ASSERT_EQUAL_DOUBLE(1920, desktop_screen3->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920 + 1280, desktop_screen4->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->screen->layout_position[1]);
 
   teardown();
   wl_display_destroy(display);
@@ -78,23 +79,25 @@ TEST(resize)
   zn_screen_layout_add(shell->screen_layout, desktop_screen3);
   zn_screen_layout_add(shell->screen_layout, desktop_screen4);
 
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 720, desktop_screen3->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 720 + 1280, desktop_screen4->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->position[1]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen1->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920 + 720, desktop_screen3->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(
+      1920 + 720 + 1280, desktop_screen4->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->screen->layout_position[1]);
 
   zn_mock_output_resize(output2, 1920, 1080);
 
-  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 1920, desktop_screen3->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->position[1]);
-  ASSERT_EQUAL_DOUBLE(1920 + 1920 + 1280, desktop_screen4->position[0]);
-  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->position[1]);
+  ASSERT_EQUAL_DOUBLE(1920, desktop_screen2->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen2->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(1920 + 1920, desktop_screen3->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen3->screen->layout_position[1]);
+  ASSERT_EQUAL_DOUBLE(
+      1920 + 1920 + 1280, desktop_screen4->screen->layout_position[0]);
+  ASSERT_EQUAL_DOUBLE(0, desktop_screen4->screen->layout_position[1]);
 
   teardown();
   wl_display_destroy(display);

--- a/zen/include/zen/screen.h
+++ b/zen/include/zen/screen.h
@@ -32,11 +32,17 @@ struct zn_screen {
 
   vec2 size;  // effective coordinate
 
+  vec2 layout_position;  // layout coordinate
+
   struct {
-    struct wl_signal resized;  // (NULL)
-    struct wl_signal destroy;  // (NULL)
+    struct wl_signal resized;                  // (NULL)
+    struct wl_signal destroy;                  // (NULL)
+    struct wl_signal layout_position_changed;  // (NULL)
   } events;
 };
+
+void zn_screen_set_layout_position(
+    struct zn_screen *self, vec2 layout_position);
 
 /// @param fbox : Effective coordinate system
 void zn_screen_damage(struct zn_screen *self, struct wlr_fbox *fbox);

--- a/zen/include/zen/snode.h
+++ b/zen/include/zen/snode.h
@@ -157,6 +157,9 @@ struct wlr_texture *zn_snode_get_texture(struct zn_snode *self);
 /// coordinate system.
 void zn_snode_get_fbox(struct zn_snode *self, struct wlr_fbox *fbox);
 
+/// @param fbox returns the box of `self` in the layout coordinate system.
+void zn_snode_get_layout_fbox(struct zn_snode *self, struct wlr_fbox *fbox);
+
 struct zn_snode *zn_snode_create(
     void *user_data, const struct zn_snode_interface *implementation);
 

--- a/zen/src/backend/backend.c
+++ b/zen/src/backend/backend.c
@@ -112,7 +112,6 @@ zn_default_backend_handle_new_output(struct wl_listener *listener, void *data)
     return;
   }
 
-  // TODO(@Aki-7): Set appropriate layout position
   wlr_output_layout_add(
       self->compositor->output_layout, output->wlr_output, 0, 0);
 

--- a/zen/src/backend/output.h
+++ b/zen/src/backend/output.h
@@ -19,6 +19,7 @@ struct zn_output {
   struct wl_listener wlr_output_destroy_listener;
   struct wl_listener damage_frame_listener;
   struct wl_listener mode_listener;
+  struct wl_listener screen_layout_position_listener;
 
   struct {
     struct wl_signal destroy;  // (NULL)

--- a/zen/src/backend/xwayland-surface.c
+++ b/zen/src/backend/xwayland-surface.c
@@ -3,6 +3,7 @@
 #include "backend.h"
 #include "zen-common/log.h"
 #include "zen-common/util.h"
+#include "zen/screen.h"
 #include "zen/seat.h"
 #include "zen/server.h"
 #include "zen/snode.h"
@@ -142,11 +143,11 @@ zn_xwayland_surface_handle_snode_position_changed(
     return;
   }
 
-  // TODO(@Aki-7): Use layout coords instead of screen-local effective coords
-  wlr_xwayland_surface_configure(self->wlr_xsurface,
-      (int16_t)self->snode->absolute_position[0],
-      (int16_t)self->snode->absolute_position[1], self->wlr_xsurface->width,
-      self->wlr_xsurface->height);
+  struct wlr_fbox fbox;
+  zn_snode_get_layout_fbox(self->view->snode, &fbox);
+
+  wlr_xwayland_surface_configure(self->wlr_xsurface, (int16_t)fbox.x,
+      (int16_t)fbox.y, self->wlr_xsurface->width, self->wlr_xsurface->height);
 }
 
 static void
@@ -183,7 +184,7 @@ zn_xwayland_surface_handle_configure(
     return;
   }
 
-  zn_snode_get_fbox(self->view->snode, &fbox);
+  zn_snode_get_layout_fbox(self->view->snode, &fbox);
 
   wlr_xwayland_surface_configure(self->wlr_xsurface, (int16_t)fbox.x,
       (int16_t)fbox.y, ev->width, ev->height);

--- a/zen/src/screen.c
+++ b/zen/src/screen.c
@@ -9,6 +9,14 @@
 #include "zen/snode.h"
 
 void
+zn_screen_set_layout_position(struct zn_screen *self, vec2 layout_position)
+{
+  glm_vec2_copy(layout_position, self->layout_position);
+
+  wl_signal_emit(&self->events.layout_position_changed, NULL);
+}
+
+void
 zn_screen_damage(struct zn_screen *self, struct wlr_fbox *fbox)
 {
   self->impl->damage(self->impl_data, fbox);
@@ -43,6 +51,7 @@ zn_screen_create(
   glm_vec2_zero(self->size);
   wl_signal_init(&self->events.resized);
   wl_signal_init(&self->events.destroy);
+  wl_signal_init(&self->events.layout_position_changed);
 
   self->snode_root = zn_snode_create_root(self);
   if (self->snode_root == NULL) {
@@ -76,6 +85,7 @@ zn_screen_destroy(struct zn_screen *self)
   zn_signal_emit_mutable(&self->events.destroy, NULL);
 
   zn_snode_destroy(self->snode_root);
+  wl_list_remove(&self->events.layout_position_changed.listener_list);
   wl_list_remove(&self->events.destroy.listener_list);
   wl_list_remove(&self->events.resized.listener_list);
   free(self);

--- a/zen/src/snode.c
+++ b/zen/src/snode.c
@@ -191,6 +191,17 @@ zn_snode_get_fbox(struct zn_snode *self, struct wlr_fbox *fbox)
   }
 }
 
+void
+zn_snode_get_layout_fbox(struct zn_snode *self, struct wlr_fbox *fbox)
+{
+  zn_snode_get_fbox(self, fbox);
+
+  if (self->screen) {
+    fbox->x += self->screen->layout_position[0];
+    fbox->y += self->screen->layout_position[1];
+  }
+}
+
 static void
 zn_snode_handle_parent_position_changed(
     struct wl_listener *listener, void *data UNUSED)


### PR DESCRIPTION
## Context

https://github.com/zwin-project/zen/issues/385

In Xwayland and xdg_output protocol, the positions of clients and outputs in the layout coordinate system are already defined in the 2D space. So we cannot omit the concept that the displays are aligned in the 2D space.

So I permit zn_screen, a zen component, to have a layout position.

## Summary

- [x] Add layout_position member to zn_screen.
- [x] Use layout coordinate position for wlr_xwayland_surface_configure. 

## How to check the behavior

Open xeyes in a display and another X app in another display.
When the cursor hovers the X app, you can confirm the the X eyes knows the layout coordinate system from its eye movement.