### PR TITLE
Partial updates on remote textures

### DIFF
--- a/include/zen/renderer/gl-texture.h
+++ b/include/zen/renderer/gl-texture.h
@@ -15,6 +15,10 @@ void znr_gl_texture_image_2d(struct znr_gl_texture *self, uint32_t target,
     int32_t border, uint32_t format, uint32_t type,
     struct zwnr_mem_storage *storage);
 
+void znr_gl_texture_sub_image_2d(struct znr_gl_texture *self, uint32_t target,
+    int32_t level, int32_t xoffset, int32_t yoffset, uint32_t width, uint32_t height,
+    uint32_t format, uint32_t type, struct zwnr_mem_storage *storage);
+
 void znr_gl_texture_generate_mipmap(
     struct znr_gl_texture *self, uint32_t target);
 

--- a/include/zen/view-child.h
+++ b/include/zen/view-child.h
@@ -14,6 +14,7 @@ struct zn_view_child_interface {
 struct zn_view_child {
   void *user_data;
   struct wlr_surface *surface;  // nonnull
+  bool surface_on_partial_updates;
 
   const struct zn_view_child_interface *impl;
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -28,6 +28,7 @@ struct zn_view_interface {
 struct zn_view {
   void *user_data;
   struct wlr_surface *surface;  // nonnull
+  bool surface_on_partial_updates;
 
   const struct zn_view_interface *impl;
 
@@ -86,6 +87,8 @@ void zn_view_move(
     struct zn_view *self, struct zn_board *board, double x, double y);
 
 void zn_view_set_maximized(struct zn_view *self, bool maximized);
+
+void zn_view_reset_partial_updates(struct zn_view *self);
 
 /** lifetime of given wlr_surface must be longer than zn_view */
 struct zn_view *zn_view_create(struct wlr_surface *surface,

--- a/zen/server.c
+++ b/zen/server.c
@@ -13,6 +13,7 @@
 #include "zen/screen/output.h"
 #include "zen/virtual-object.h"
 #include "zen/wlr/render/glew.h"
+#include "zen/view.h"
 
 static struct zn_server *server_singleton = NULL;
 
@@ -79,6 +80,7 @@ zn_server_change_display_system(
     struct zn_server *self, enum zn_display_system_state display_system)
 {
   struct zn_screen *screen;
+  struct zn_view *view;
 
   if (self->display_system == display_system) return;
 
@@ -86,6 +88,10 @@ zn_server_change_display_system(
 
   wl_list_for_each (screen, &self->scene->screen_layout->screen_list, link) {
     zn_screen_damage_whole(screen);
+  }
+
+  wl_list_for_each (view, &self->scene->view_list, link) {
+    zn_view_reset_partial_updates(view);
   }
 
   self->display_system = display_system;

--- a/zen/view-child.c
+++ b/zen/view-child.c
@@ -134,6 +134,7 @@ zn_view_child_create(struct wlr_surface *surface, struct zn_view *view,
 
   self->user_data = user_data;
   self->surface = surface;
+  self->surface_on_partial_updates = false;
   self->impl = impl;
   self->view = view;
 

--- a/zen/view.c
+++ b/zen/view.c
@@ -268,6 +268,10 @@ zn_view_set_maximized(struct zn_view *self, bool maximized)
   self->maximize_status.maximized = maximized;
 }
 
+void zn_view_reset_partial_updates(struct zn_view *self){
+  self->surface_on_partial_updates = false;
+}
+
 struct zn_view *
 zn_view_create(struct wlr_surface *surface,
     const struct zn_view_interface *impl, void *user_data)
@@ -282,6 +286,7 @@ zn_view_create(struct wlr_surface *surface,
   }
 
   self->surface = surface;
+  self->surface_on_partial_updates = false;
   self->impl = impl;
   self->user_data = user_data;
 

--- a/zna/base-unit.h
+++ b/zna/base-unit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cairo.h>
+#include <pixman.h>
 #include <wayland-server-core.h>
 #include <wlr/render/wlr_texture.h>
 #include <zwnr/gl-base-technique.h>
@@ -55,7 +56,8 @@ void zna_base_unit_read_cairo_surface(
     struct zna_base_unit *self, cairo_surface_t *surface);
 
 void zna_base_unit_read_wlr_texture(
-    struct zna_base_unit *self, struct wlr_texture *texture);
+    struct zna_base_unit *self, struct wlr_texture *texture,
+    pixman_region32_t *damage, bool *on_partial_updates);
 
 void zna_base_unit_setup_renderer_objects(struct zna_base_unit *self,
     struct znr_dispatcher *dispatcher,

--- a/zna/cursor.c
+++ b/zna/cursor.c
@@ -29,7 +29,7 @@ zna_cursor_commit(struct zna_cursor *self, uint32_t damage)
 
   if (damage & ZNA_CURSOR_DAMAGE_TEXTURE) {
     zna_base_unit_read_wlr_texture(
-        self->base_unit, zn_cursor_get_texture(self->zn_cursor));
+        self->base_unit, zn_cursor_get_texture(self->zn_cursor), NULL, NULL);
     znr_gl_sampler_parameter_i(
         self->base_unit->sampler0, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     znr_gl_sampler_parameter_i(

--- a/zna/view-child.c
+++ b/zna/view-child.c
@@ -27,7 +27,9 @@ zna_view_child_commit(struct zna_view_child *self, uint32_t damage)
     struct wlr_texture *texture =
         wlr_surface_get_texture(self->zn_view_child->surface);
     if (texture) {
-      zna_base_unit_read_wlr_texture(self->base_unit, texture);
+      zna_base_unit_read_wlr_texture(self->base_unit, texture,
+          &self->zn_view_child->surface->buffer_damage,
+          &self->zn_view_child->surface_on_partial_updates);
       znr_gl_texture_generate_mipmap(self->base_unit->texture0, GL_TEXTURE_2D);
       znr_gl_sampler_parameter_i(
           self->base_unit->sampler0, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/zna/view.c
+++ b/zna/view.c
@@ -27,7 +27,9 @@ zna_view_commit(struct zna_view *self, uint32_t damage)
     struct wlr_texture *texture =
         wlr_surface_get_texture(self->zn_view->surface);
     if (texture) {
-      zna_base_unit_read_wlr_texture(self->base_unit, texture);
+      zna_base_unit_read_wlr_texture(self->base_unit, texture,
+        &self->zn_view->surface->buffer_damage,
+        &self->zn_view->surface_on_partial_updates);
       znr_gl_texture_generate_mipmap(self->base_unit->texture0, GL_TEXTURE_2D);
       znr_gl_sampler_parameter_i(
           self->base_unit->sampler0, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/znr-remote/src/gl-texture.cc
+++ b/znr-remote/src/gl-texture.cc
@@ -24,6 +24,24 @@ znr_gl_texture_image_2d(struct znr_gl_texture *self, uint32_t target,
 }
 
 void
+znr_gl_texture_sub_image_2d(struct znr_gl_texture *self, uint32_t target,
+    int32_t level, int32_t xoffset, int32_t yoffset, uint32_t width, uint32_t height,
+    uint32_t format, uint32_t type,
+    struct zwnr_mem_storage *storage)
+{
+  auto loop = std::make_unique<Loop>(wl_display_get_event_loop(self->display));
+
+  zwnr_mem_storage_ref(storage);
+
+  auto buffer = zen::remote::server::CreateBuffer(
+      storage->data, [storage] { zwnr_mem_storage_unref(storage); },
+      std::move(loop));
+
+  self->proxy->GlTexSubImage2D(target, level, xoffset, yoffset, width, height,
+      format, type, std::move(buffer));
+}
+
+void
 znr_gl_texture_generate_mipmap(struct znr_gl_texture *self, uint32_t target)
 {
   self->proxy->GlGenerateMipmap(target);


### PR DESCRIPTION
## Context

<!--
Please provide a link to the relevant issue, if available,
so that reviewers can quickly understand the context.

Example:
See zwin-project/.github#8
-->

It is probably the relevant issue: https://github.com/zwin-project/zwin/issues/17

<!--
If the issue is not well described, add more information here (justification,
pull request links, etc.).
-->
The issue is slow texture updates. The slowing depend on a window size due to full window update instead of its partial damaged rectangles.
## Summary

- Added new one function `znr_gl_texture_sub_image_2d` that maps to the `glTexSubImage2D` on a remote side. It is done with the same way as existed `znr_gl_texture_image_2d` that maps to the `glTexImage2D`.
- Added flags to the `zn_view` and the `zn_view_child` for indicating that a full texture was loaded, and it is ready for the partial updates.
- The main changes are done in `zna_base_unit_read_wlr_texture`. It checks the flag and does full texture update or partial.

<!--
Please describe what you did here. If you have made changes to the appearance,
it would be helpful to include images as well.
-->

## How to check the behavior

<!--
If you have added a new feature, please write a way for other developers
to easily check the behavior you have changed or added, so that they can
keep up with the changes.
-->

1. Open Nautilus
2. Open a folder where is several items
3. Maximize the window
4. Move the cursor through the item list
5. Redrawing of selected items are queueing and finishes several seconds later after the cursor path. The request fixes it.
